### PR TITLE
Use SchemaStatements#data_sources instead of the deprecated 'tables'

### DIFF
--- a/lib/fixation/fixtures.rb
+++ b/lib/fixation/fixtures.rb
@@ -77,7 +77,8 @@ module Fixation
     end
 
     def clear_other_tables(connection)
-      (connection.tables - Fixation.tables_not_to_clear - @statements.keys).each do |table_name|
+      data_sources = connection.respond_to?(:data_sources) ? connection.data_sources : connection.tables
+      (data_sources - Fixation.tables_not_to_clear - @statements.keys).each do |table_name|
         connection.execute("DELETE FROM #{connection.quote_table_name table_name}")
       end
     end


### PR DESCRIPTION
Using tables causes deprecation warnings on Rails 5.0 and has been
removed in Rails 5.1.