### PR TITLE
Load `.yml.erb` fixtures from fixture paths by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ if Rails.env.test? && Fixation.running_under_spring?
 end
 ```
 
+## Included fixture file extensions
+
+Fixation will load files with either the `.yml` or `.yml.erb` extension from the configured fixture paths. You can change this in your initializer in a similar fashion to the fixture paths:
+
+```ruby
+if Rails.env.test?
+  Fixation.extensions = %w(.yml .other.extension)
+end
+```
+
 ## Auto-clearing other tables
 
 By default Fixation will only reset those tables that have a fixture file, like Rails.  Optionally, you can tell it to clear all other tables so that you don't need to make empty fixture files.

--- a/lib/fixation.rb
+++ b/lib/fixation.rb
@@ -8,9 +8,13 @@ require_relative "fixation/fixture_table"
 require_relative "fixation/fixtures"
 
 module Fixation
-  # The list of paths to look in to find .yml fixture files.
+  # The list of paths to look in to find fixture files.
   cattr_accessor :paths
   self.paths = %w(test/fixtures spec/fixtures)
+
+  # The list of extensions to look for in fixture directories.
+  cattr_accessor :extensions
+  self.extensions = %w(.yml .yml.erb)
 
   # Set to true to clear any tables found in the database that do *not* have a fixture file.
   cattr_accessor :clear_other_tables

--- a/lib/fixation/fixtures.rb
+++ b/lib/fixation/fixtures.rb
@@ -15,9 +15,11 @@ module Fixation
       @loaded_at = ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
 
       Fixation.paths.each do |path|
-        Dir["#{path}/{**,*}/*.yml"].each do |pathname|
-          basename = pathname[path.size + 1..-5]
-          load_fixture_file(pathname, basename, connection) if ::File.file?(pathname)
+        Fixation.extensions.each do |extension|
+          Dir["#{path}/{**,*}/*#{extension}"].each do |pathname|
+            basename = pathname[path.size + 1..-(extension.size + 1)]
+            load_fixture_file(pathname, basename, connection) if ::File.file?(pathname)
+          end
         end
       end
 


### PR DESCRIPTION
This is now also configurable, but the new default with load files with
either extension.

Closes #3